### PR TITLE
Lazy-load resources

### DIFF
--- a/redfish_client/__init__.py
+++ b/redfish_client/__init__.py
@@ -17,9 +17,10 @@ from redfish_client.caching_connector import CachingConnector
 from redfish_client.root import Root
 
 
-def connect(base_url, username, password, verify=True, cache=True):
+def connect(base_url, username, password, verify=True, cache=True,
+            lazy_load=True):
     klass = CachingConnector if cache else Connector
     connector = klass(base_url, username, password, verify=verify)
-    root = Root(connector, oid="/redfish/v1")
+    root = Root(connector, oid="/redfish/v1", lazy=lazy_load)
     root.login()
     return root

--- a/redfish_client/root.py
+++ b/redfish_client/root.py
@@ -17,9 +17,10 @@ from redfish_client.resource import Resource
 
 class Root(Resource):
     def login(self):
-        sessions = self._content.get("Links", {}).get("Sessions", {})
+        content = self._get_content()
+        sessions = content.get("Links", {}).get("Sessions", {})
         authenticated_path = next(
-            i["@odata.id"] for i in self._content.values() if "@odata.id" in i
+            i["@odata.id"] for i in content.values() if "@odata.id" in i
         )
         if "@odata.id" in sessions:
             self._connector.set_session_auth_data(sessions["@odata.id"])
@@ -31,4 +32,4 @@ class Root(Resource):
         self._connector.logout()
 
     def find(self, oid):
-        return Resource(self._connector, oid=oid)
+        return Resource(self._connector, oid=oid, lazy=self._is_lazy)


### PR DESCRIPTION
Until now, we eagerly loaded `Resource`'s content as soon as we built it. This proved to be a bit awkward for resources with many siblings, as accessing the contents of one such resource resulted in fetching of the sibling resources' contents as well.

With this commit, we substitute this behavior with lazy loading. Rather than fetching the content of a resource immediately upon being built, we delay it until it is accessed.