### PR TITLE
Add a default timeout to the redfish requests

### DIFF
--- a/redfish_client/__init__.py
+++ b/redfish_client/__init__.py
@@ -18,9 +18,9 @@ from redfish_client.root import Root
 
 
 def connect(base_url, username, password, verify=True, cache=True,
-            lazy_load=True):
+            lazy_load=True, timeout=Connector.DEFAULT_TIMEOUT):
     klass = CachingConnector if cache else Connector
-    connector = klass(base_url, username, password, verify=verify)
+    connector = klass(base_url, username, password, verify=verify, timeout=timeout)
     root = Root(connector, oid="/redfish/v1", lazy=lazy_load)
     root.login()
     return root


### PR DESCRIPTION
Python requests library has timout set to None by default, which means it'll wait (hang) until the connection is closed.

In this commit, we introduce the default timeout and also add a parameter to the Connector that allows us to modify this value.

Related issues: https://github.com/Metify-io/coordinator/issues/401, https://github.com/Metify-io/coordinator/issues/391, https://github.com/Metify-io/yoda-design/issues/66