### PR TITLE
Allow empty body for POST requests

### DIFF
--- a/redfish_client/connector.py
+++ b/redfish_client/connector.py
@@ -52,7 +52,7 @@ class Connector:
         return self._base_url + path
 
     def _request(self, method, path, payload=None):
-        args = dict(json=payload) if payload else {}
+        args = dict(json=payload) if payload is not None else {}
         try:
             resp = self._client.request(method, self._url(path), **args, timeout=self._timeout)
         except requests.exceptions.ConnectionError:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -278,6 +278,15 @@ class TestPost:
         status, *_ = conn.post("/post", dict(post="payload"))
         assert status == 200
 
+    def test_post_empty_payload(self, requests_mock):
+        requests_mock.post(
+            "https://demo.dev/post", status_code=200,
+            additional_matcher=lambda r: r.json() == {}
+        )
+        conn = Connector("https://demo.dev", None, None)
+        status, *_ = conn.post("/post", dict())
+        assert status == 200
+
 
 class TestPatch:
     def test_patch_no_payload(self, requests_mock):
@@ -293,6 +302,15 @@ class TestPatch:
         )
         conn = Connector("https://demo.dev", None, None)
         status, *_ = conn.patch("/patch", dict(patch="payload"))
+        assert status == 200
+
+    def test_patch_empty_payload(self, requests_mock):
+        requests_mock.patch(
+            "https://demo.dev/patch", status_code=200,
+            additional_matcher=lambda r: r.json() == {}
+        )
+        conn = Connector("https://demo.dev", None, None)
+        status, *_ = conn.patch("/patch", dict())
         assert status == 200
 
 


### PR DESCRIPTION
Sending a request with empty curly brackets currently resulted in a request with no body at all. Some redfish endpoints (like eject virtual media) require empty curly brackets in the body.

In this commit, we change how the body is parsed and sent to the requests library.

