### PR TITLE
Make attribute access lazy

### DIFF
--- a/redfish_client/resource.py
+++ b/redfish_client/resource.py
@@ -99,6 +99,8 @@ class Resource:
         return self[name]
 
     def __getitem__(self, name):
+        if name in self._content:
+            return self._build(self._content[name])
         return self._build(self._get_content()[name])
 
     def __contains__(self, item):

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -33,6 +33,9 @@ class TestGetKey:
         with pytest.raises(ResourceNotFound):
             Resource(connector, oid="id", data={}).raw
 
+    def test_wrong_id_without_fail_oid(self):
+        assert Resource(None, oid="id", data={})["@odata.id"] == "id"
+
     def test_get_invalid_key(self):
         with pytest.raises(KeyError):
             Resource(None, data={}).Invalid_key


### PR DESCRIPTION
If the attribute we are trying to access already exists in the local data, we skip the GET requests to the API and just return whatever value we have at hand. This is most useful if we are only interested in the resource ids and no other resource data.

Fixes #25 