### PR TITLE
Fix uncaught exception

### DIFF
--- a/redfish_client/connector.py
+++ b/redfish_client/connector.py
@@ -66,7 +66,7 @@ class Connector:
 
         try:
             json_data = resp.json()
-        except json.JSONDecodeError:
+        except ValueError:
             json_data = None
         headers = dict(resp.headers.lower_items())
 


### PR DESCRIPTION
`simplejson.decoder.JSONDecodeError` does not get caught by `json.JSONDecodeError`.
We thus use `ValueError` exception to handle both cases.
Discussion: https://stackoverflow.com/questions/8381193/handle-json-decode-error-when-nothing-returned