### PR TITLE
Logging of the requests and responses

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,6 @@ jobs:
       - image: cimg/python:<< parameters.python >>
     steps:
       - checkout
-      - run: pip install pytest requests-mock
+      - run: pip install pytest requests-mock pytest-mock
       - run: pip install .
       - run: pytest tests

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 pylint = "*"
 pytest = "*"
 pytest-cov = "*"
+pytest-mock = "*"
 requests-mock = "*"
 
 [packages]


### PR DESCRIPTION
This adds logging of the requests and the responses received. The client instantiates a logger named `redfish-client`.

Before running an HTTP request it logs the details of the request, e.g.:

```
{
  "request": {
    "method": "GET",
    "path": "/redfish/v1",
    "payload": {"data": ... }
  }
}
```

After it collects the response, it logs the details:

```
{
  "request_data": {
    "method": "GET",
    "path": "/redfish/v1"
  },
  "response": {
    "status_code": 200,
    "headers": {
      "content-type": "application/json",
      "server": "WEBrick/1.4.2 (Ruby/2.5.1/2018-03-29) OpenSSL/1.1.1",
      "date": "Tue, 01 Feb 2022 10:11:09 GMT",
      "content-length": "468",
      "connection": "Keep-Alive"
    },
    "content": "b'{\"@odata.id\":\"/redfish/v1/\",\"Chassis\":{\"@odata.id\":\"/redfish/v1/Chassis\"},\"EventService\":{\"@odata.id\":\"/redfish/v1/EventService\"},\"Id\":\"RootService\",\"Links\":{\"Sessions\":{\"@odata.id\":\"/redfish/v1/SessionService/Sessions\"}},\"Name\":\"RackManager Root Service\",\"SessionService\":{\"@odata.id\":\"/redfish/v1/SessionService\"},\"Systems\":{\"@odata.id\":\"/redfish/v1/Systems\"},\"Tasks\":{\"@odata.id\":\"/redfish/v1/TaskService\"},\"UpdateService\":{\"@odata.id\":\"/redfish/v1/UpdateService\"}}'",
    "json_data": {                                                                                                                                                            [6/43]      "@odata.id": "/redfish/v1/",
      "Chassis": {
        "@odata.id": "/redfish/v1/Chassis"
      },
      "EventService": {
        "@odata.id": "/redfish/v1/EventService"
      },
      "Id": "RootService",
      "Links": {
        "Sessions": {
          "@odata.id": "/redfish/v1/SessionService/Sessions"
        }
      },
      "Name": "RackManager Root Service",
      "SessionService": {
        "@odata.id": "/redfish/v1/SessionService"
      },
      "Systems": {
        "@odata.id": "/redfish/v1/Systems"
      },
      "Tasks": {
        "@odata.id": "/redfish/v1/TaskService"
      },
      "UpdateService": {
        "@odata.id": "/redfish/v1/UpdateService"
      }
    }
  }
```

The `request_data` is there to have some way of tieing the response to a request. The `response` then contains:
* `status_code`
* `headers` - the headers in the response.
* `content` - a string of characters containing the response's payload.
* `json_data` - the contents formatted as JSON.

To enable the logging, the appropriate `LOGGING` settings need to be in place. E.g.:

```
LOGGING = {
    'version': 1,
    'disable_existing_loggers': False,
    'handlers': {
        'console': {
            'level': 'DEBUG',
            'class': 'logging.StreamHandler',
            'formatter': 'redfish-client'
        },
        'redfish-client': {
            'level': 'DEBUG',
            'class': 'logging.handlers.TimedRotatingFileHandler',
            'filename': '/var/log/yoda/redfish-client.log',
            'when': 'midnight',
            'backupCount': 5,
            'formatter': 'redfish-client',
        },
    },
    'formatters': {
        'redfish-client': {
            'format': '[%(asctime)s][%(levelname)s] [redfish client] %(message)s',
        },
    },
    'loggers': {
        'redfish-client': {
            'handlers': ['redfish-client'],
            'level': 'DEBUG',
            'propagate': True,
        },
    },
}
```