### PR TITLE
Loging base url of the requests and responses

### DIFF
--- a/redfish_client/connector.py
+++ b/redfish_client/connector.py
@@ -58,6 +58,7 @@ class Connector:
             logger.debug(json.dumps(dict(
                 request=dict(
                     method=method,
+                    base_url=self._base_url,
                     path=path,
                     payload=payload
                 )
@@ -70,6 +71,7 @@ class Connector:
             logger.debug(json.dumps(dict(
                 request_data=dict(
                     method=method,
+                    base_url=self._base_url,
                     path=path
                 ),
                 response=dict(

--- a/redfish_client/connector.py
+++ b/redfish_client/connector.py
@@ -1,4 +1,4 @@
-#  Copyright 2018 XLAB d.o.o.
+#  Copyright 2022 XLAB d.o.o.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -379,9 +379,13 @@ class TestLogging:
         logging_error_mock.assert_not_called()
         logging_debug_mock.assert_has_calls(
             [
-                mocker.call('{"request": {"method": "GET", "path": "/1", "payload": null}}'),
+                mocker.call('{"request": {'
+                                '"method": "GET", "base_url": "https://demo.dev", '
+                                '"path": "/1", "payload": null}'
+                            '}'),
                 mocker.call('GET https://demo.dev/1 200'),
-                mocker.call('{"request_data": {"method": "GET", "path": "/1"}, '
+                mocker.call('{"request_data": '
+                            '{"method": "GET", "base_url": "https://demo.dev", "path": "/1"}, '
                             '"response": {"status_code": 200, "headers": {}, '
                                 '"content": "b\'{\\"hello\\": \\"fish\\"}\'", '
                                 '"json_data": {"hello": "fish"}}'
@@ -402,9 +406,13 @@ class TestLogging:
         logging_error_mock.assert_not_called()
         logging_debug_mock.assert_has_calls(
             [
-                mocker.call('{"request": {"method": "POST", "path": "/1", "payload": {"iam": "cat"}}}'),
+                mocker.call('{"request": {'
+                                '"method": "POST", "base_url": "https://demo.dev", '
+                                '"path": "/1", "payload": {"iam": "cat"}}'
+                            '}'),
                 mocker.call('POST https://demo.dev/1 200'),
-                mocker.call('{"request_data": {"method": "POST", "path": "/1"}, '
+                mocker.call('{"request_data": '
+                            '{"method": "POST", "base_url": "https://demo.dev", "path": "/1"}, '
                             '"response": {"status_code": 200, "headers": {}, '
                                 '"content": "b\'{\\"hello\\": \\"fish\\"}\'", '
                                 '"json_data": {"hello": "fish"}}'

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1,4 +1,4 @@
-#  Copyright 2019 XLAB d.o.o.
+#  Copyright 2022 XLAB d.o.o.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.


### PR DESCRIPTION
The logs were only partially useful, but when we had multiple processes sending requests to multiple servers it was difficult to see which log entry belonged to which server host.
This adds `base_url` output to identify the target server as well.