### PR TITLE
Add a custom __dir__ implementation to Resource to support auto-completion

### DIFF
--- a/redfish_client/resource.py
+++ b/redfish_client/resource.py
@@ -55,6 +55,12 @@ class Resource:
             self._content = data
             self._headers = {}
 
+    def __dir__(self):
+        result = [key for key in super().__dir__() if not key.startswith("_")]
+        if self._content:
+            result += [key for key in self._content.keys() if not key.startswith("@")]
+        return result
+
     def _init_from_oid(self, oid):
         if "#" in oid:
             url, fragment = oid.split("#", 1)

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -45,6 +45,15 @@ class TestGetKey:
             "ProcessorSummary": {"State": "Enabled"}
         }).dig("ProcessorSummary", "State") == "Enabled"
 
+    def test_keys_in_dir(self):
+        res = Resource(None,data={
+            "ProcessorSummary": {"State": "Enabled"},
+            "@odata.dummy": "Dummy",
+        })
+        assert "ProcessorSummary" in dir(res)
+        assert "@odata.dummy" not in dir(res)
+        assert "dig" in dir(res)
+        assert "_get_content" not in dir(res)
 
 class TestExecuteAction:
     def setup_method(self,):


### PR DESCRIPTION
Interactive Python environments such as IPython and modern versions of regular (C) Python support auto-completion for object attributes by inspecting the list returned by `dir()`. Under the hood the built-in function attempts to call `__dir__()` to see if the object has a custom list of attributes. This PR adds an implementation of a custom `__dir__()` method for `Resource` objects that returns the known attributes of the resource as well as the regular methods for resources, allowing for auto-completion as the resource hierarchy is browsed interactively. This is even more effective if the client connects with `lazy_load=False`, but will work one layer deep without this option.

The implementation here hides both internal methods (i.e. those beginning with `_` characters) and also Redfish internal attributes (those beginning with `@`) in the result set, although these are still accessible directly.

Tests for the new method have been added to `tests/test_resource.py`.

_Note_: due to a known bug in the `jedi` library, modern versions of IPython have problems performing auto-completion on objects that offer custom implementations of `__dir__`. This bug can be avoided by executing `%config IPCompleter.use_jedi = False` to disable use of the buggy library.