### PR TITLE
Strip non-path components from location header when used for session id

### DIFF
--- a/redfish_client/connector.py
+++ b/redfish_client/connector.py
@@ -16,6 +16,7 @@ import base64
 import collections
 import json
 import logging
+from urllib.parse import urlparse
 
 import requests
 
@@ -151,9 +152,12 @@ class Connector:
         self._set_header("x-auth-token", resp.headers["x-auth-token"])
         # We combine with `or` here because the default value of the dict.get
         # method is eagerly evaluated, which is not what we want.
-        self._session_id = (
-            resp.headers.get("location") or resp.json()["@odata.id"]
-        )
+        sess_id = resp.headers.get("location") or resp.json()["@odata.id"]
+        try:
+            sess_id = urlparse(sess_id).path
+        except BaseException:
+            pass
+        self._session_id = sess_id
 
     def _session_logout(self):
         if self._session_id:


### PR DESCRIPTION
Some RedFish implementations (HPE/iLO 4 and 5) were returning the full URI in the "location" header. Logout would fail for these implementations becuase the _session_logout() assumes just a path is returned. This is an issue with the RedFish implementation but seems like a harmless fix to include in the library.