### PR TITLE
Support for adding customer headers to each request

### DIFF
--- a/redfish_client/resource.py
+++ b/redfish_client/resource.py
@@ -201,7 +201,7 @@ class Resource:
             return field
         return path
 
-    def post(self, payload=None):
+    def post(self, payload=None, headers=None):
         """
         Perform a POST at the resource with the given payload.
 
@@ -211,9 +211,9 @@ class Resource:
         path = self._content.get("@odata.id")
         if not path:
             raise MissingOidException("The resource cannot be POSTed to.")
-        return self._connector.post(path, payload=payload)
+        return self._connector.post(path, payload=payload, headers=headers)
 
-    def patch(self, payload):
+    def patch(self, payload, headers=None):
         """
         Perform a PATCH at the resource with the given payload.
 
@@ -223,9 +223,9 @@ class Resource:
         path = self._content.get("@odata.id")
         if not path:
             raise MissingOidException("The resource cannot be PATCHed.")
-        return self._connector.patch(path, payload=payload)
+        return self._connector.patch(path, payload=payload, headers=headers)
 
-    def put(self, path=None, payload=None):
+    def put(self, path=None, payload=None, headers=None):
         """
         Perform a PUT at the resource or selected path with the given payload.
 
@@ -237,13 +237,13 @@ class Resource:
         path = self._get_path(field, path)
         if not path:
             raise MissingOidException("The resource cannot be PUT.")
-        return self._connector.put(path, payload=payload)
+        return self._connector.put(path, payload=payload, headers=headers)
 
-    def delete(self):
+    def delete(self, headers=None):
         """
         Perform a DELETE at the resource.
         """
         path = self._content.get("@odata.id")
         if not path:
             raise MissingOidException("The resource cannot be DELETEd.")
-        return self._connector.delete(path)
+        return self._connector.delete(path, headers=headers)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -381,7 +381,7 @@ class TestLogging:
             [
                 mocker.call('{"request": {'
                                 '"method": "GET", "base_url": "https://demo.dev", '
-                                '"path": "/1", "payload": null}'
+                                '"path": "/1", "payload": null, "headers": null}'
                             '}'),
                 mocker.call('GET https://demo.dev/1 200'),
                 mocker.call('{"request_data": '
@@ -408,7 +408,7 @@ class TestLogging:
             [
                 mocker.call('{"request": {'
                                 '"method": "POST", "base_url": "https://demo.dev", '
-                                '"path": "/1", "payload": {"iam": "cat"}}'
+                                '"path": "/1", "payload": {"iam": "cat"}, "headers": null}'
                             '}'),
                 mocker.call('POST https://demo.dev/1 200'),
                 mocker.call('{"request_data": '

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -154,8 +154,21 @@ class TestPost:
             "@odata.id": "/redfish/v1/EventService/Subscriptions/"
         }).post(payload={"Destination": "http://123.10.10.234"})
         connector.post.assert_called_once_with(
-            "/redfish/v1/EventService/Subscriptions/", payload={"Destination":
-            "http://123.10.10.234"})
+            "/redfish/v1/EventService/Subscriptions/",
+            payload={"Destination": "http://123.10.10.234"},
+            headers=None
+        )
+
+    def test_post_on_resource_custom_header(self):
+        connector = mock.Mock(spec=Connector)
+        Resource(connector, data={
+            "@odata.id": "/redfish/v1/EventService/Subscriptions/"
+        }).post(payload={"Destination": "http://123.10.10.234"}, headers={"Custom": "Header"})
+        connector.post.assert_called_once_with(
+            "/redfish/v1/EventService/Subscriptions/",
+            payload={"Destination": "http://123.10.10.234"},
+            headers={"Custom": "Header"}
+        )
 
     def test_post_on_resource_invalid(self):
         connector = mock.Mock(spec=Connector)
@@ -171,7 +184,20 @@ class TestDelete:
             }
         ).delete()
         connector.delete.assert_called_once_with(
-            "/redfish/v1/Managers/Steampunk/Accounts/4")
+            "/redfish/v1/Managers/Steampunk/Accounts/4",
+            headers=None
+        )
+
+    def test_delete_a_resource_custom_header(self):
+        connector = mock.Mock(spec=Connector)
+        Resource(connector, data={
+            "@odata.id": "/redfish/v1/Managers/Steampunk/Accounts/4"
+            }
+        ).delete(headers={"Custom": "Header"})
+        connector.delete.assert_called_once_with(
+            "/redfish/v1/Managers/Steampunk/Accounts/4",
+            headers={"Custom": "Header"}
+        )
 
     def test_delete_an_invalid_resource(self):
         connector = mock.Mock(spec=Connector)
@@ -186,7 +212,21 @@ class TestPatch:
             "@odata.id": "/redfish/v1/Systems/1"
         }).patch(payload={"Misc": "MyValue"})
         connector.patch.assert_called_once_with(
-            "/redfish/v1/Systems/1", payload={"Misc": "MyValue"})
+            "/redfish/v1/Systems/1",
+            payload={"Misc": "MyValue"},
+            headers=None
+        )
+
+    def test_patch_a_resource_custom_header(self):
+        connector = mock.Mock(spec=Connector)
+        Resource(connector, data={
+            "@odata.id": "/redfish/v1/Systems/1"
+        }).patch(payload={"Misc": "MyValue"}, headers={"Custom": "Header"})
+        connector.patch.assert_called_once_with(
+            "/redfish/v1/Systems/1",
+            payload={"Misc": "MyValue"},
+            headers={"Custom": "Header"}
+        )
 
     def test_patch_an_invalid_resource(self):
         connector = mock.Mock(spec=Connector)
@@ -201,7 +241,21 @@ class TestPut:
             "@odata.id": "/redfish/v1/Systems/1"
         }).put(payload={"Misc": "MyValue"})
         connector.put.assert_called_once_with(
-            "/redfish/v1/Systems/1", payload={"Misc": "MyValue"})
+            "/redfish/v1/Systems/1",
+            payload={"Misc": "MyValue"},
+            headers=None
+        )
+
+    def test_put_a_resource_custom_header(self):
+        connector = mock.Mock(spec=Connector)
+        Resource(connector, data={
+            "@odata.id": "/redfish/v1/Systems/1"
+        }).put(payload={"Misc": "MyValue"}, headers={"Custom": "Header"})
+        connector.put.assert_called_once_with(
+            "/redfish/v1/Systems/1",
+            payload={"Misc": "MyValue"},
+            headers={"Custom": "Header"}
+        )
 
     def test_put_a_resource_with_path(self):
         connector = mock.Mock(spec=Connector)
@@ -209,7 +263,10 @@ class TestPut:
             "@odata.id": "/redfish/v1/Systems/1"
         }).put(path="/redfish/v1/custom/path", payload={"Misc": "MyValue"})
         connector.put.assert_called_once_with(
-            "/redfish/v1/custom/path", payload={"Misc": "MyValue"})
+            "/redfish/v1/custom/path",
+            payload={"Misc": "MyValue"},
+            headers=None
+        )
 
     def test_put_an_invalid_resource(self):
         connector = mock.Mock(spec=Connector)


### PR DESCRIPTION
Some Redfish implementations (namely OpenBMC) require an If-Match header on some actions. For example, IndicatorLED state requires the etag that was returned from the parent state request. This adds support for passing through additional headers as needed.

Example usage:

```python
etag = node.raw.get('@odata.etag', '*')
node.patch(
    dict(IndicatorLED='Lit'),
    headers={
        "If-Match": etag
    }
)
```